### PR TITLE
Fixed skewed camera

### DIFF
--- a/Flying Frisbee Game/Assets/Scripts/MovementManager.cs
+++ b/Flying Frisbee Game/Assets/Scripts/MovementManager.cs
@@ -75,12 +75,13 @@ public class MovementManager : MonoBehaviour
         currentMoveCoroutine = MoveCameraToTopView();
         StartCoroutine(currentMoveCoroutine);
     }
+
     private IEnumerator MoveCameraToTopView()
     {
         while ((mainCameraRig.transform.position - targetTopViewPosition).sqrMagnitude > 0.001f)
         {
             mainCameraRig.transform.position = Vector3.Lerp(mainCameraRig.transform.position, targetTopViewPosition, lerpSpeed);
-            mainCameraRig.transform.rotation = Quaternion.Lerp(mainCameraRig.transform.rotation, targetTopViewRotation, lerpSpeed);
+            mainCameraRig.transform.rotation = Quaternion.Lerp(mainCameraRig.transform.rotation, targetTopViewRotation, 1.5f * lerpSpeed);
             yield return null;
         }
         Debug.Log("Moved camera to Movement Manager view");
@@ -108,7 +109,7 @@ public class MovementManager : MonoBehaviour
         while ((mainCameraRig.transform.position - targetPosition).sqrMagnitude > 1f)
         {
             mainCameraRig.transform.position = Vector3.Lerp(mainCameraRig.transform.position, targetPosition, lerpSpeed);
-            mainCameraRig.transform.rotation = Quaternion.Lerp(mainCameraRig.transform.rotation, initialCameraRigRotation, lerpSpeed);
+            mainCameraRig.transform.rotation = Quaternion.Lerp(mainCameraRig.transform.rotation, initialCameraRigRotation, 1.5f * lerpSpeed);
             yield return null;
         }
         Debug.Log("Moved camera to play view");


### PR DESCRIPTION
Resolves #21 
After resuming to the play view (from the movement manager view) the camera angle was skewed.
This was because the stop condition to move the camera back was just depending on the position. When the camera reached the correct position, the rotation was not entirely finished resulting in a slightly skewed camera.

Fix: I could have added the rotation as an extra condition, but I decided to make the rotation faster instead. Now the camera is in the correct orientation, before the target position is reached.